### PR TITLE
Add MaterialAddons Button and ButtonGroups

### DIFF
--- a/projects/material-addons/package.json
+++ b/projects/material-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@porscheinformatik/material-addons",
-  "version": "15.0.8",
+  "version": "15.0.9",
   "description": "Custom theme and components for Angular Material",
   "homepage": "https://github.com/porscheinformatik/material-addons",
   "repository": {

--- a/projects/material-addons/src/lib/button/button.module.ts
+++ b/projects/material-addons/src/lib/button/button.module.ts
@@ -1,18 +1,43 @@
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
-import { MatTooltipModule } from '@angular/material/tooltip';
-import { PrimaryButtonComponent } from './primary-button/primary-button.component';
-import { OutlineButtonComponent } from './outline-button/outline-button.component';
-import { LinkButtonComponent } from './flat-button/link-button.component';
-import { IconButtonComponent } from './icon-button/icon-button.component';
-import { DangerButtonComponent } from './danger-button/danger-button.component';
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {RouterModule} from '@angular/router';
+import {MatButtonModule} from '@angular/material/button';
+import {MatIconModule} from '@angular/material/icon';
+import {MatTooltipModule} from '@angular/material/tooltip';
+import {PrimaryButtonComponent} from './primary-button/primary-button.component';
+import {OutlineButtonComponent} from './outline-button/outline-button.component';
+import {LinkButtonComponent} from './flat-button/link-button.component';
+import {IconButtonComponent} from './icon-button/icon-button.component';
+import {DangerButtonComponent} from './danger-button/danger-button.component';
+import {MadButtonDirective} from './mad-button/mad-button.directive';
+import {MadButtonGroupComponent} from './mad-button-group/mad-button-group.component';
 
 @NgModule({
-  declarations: [PrimaryButtonComponent, OutlineButtonComponent, LinkButtonComponent, DangerButtonComponent, IconButtonComponent],
-  imports: [CommonModule, RouterModule, MatButtonModule, MatIconModule, MatTooltipModule],
-  exports: [PrimaryButtonComponent, OutlineButtonComponent, LinkButtonComponent, DangerButtonComponent, IconButtonComponent],
+  declarations: [
+    PrimaryButtonComponent,
+    OutlineButtonComponent,
+    LinkButtonComponent,
+    DangerButtonComponent,
+    IconButtonComponent,
+    MadButtonDirective,
+    MadButtonGroupComponent,
+  ],
+  imports: [
+    CommonModule,
+    RouterModule,
+    MatButtonModule,
+    MatIconModule,
+    MatTooltipModule
+  ],
+  exports: [
+    PrimaryButtonComponent,
+    OutlineButtonComponent,
+    LinkButtonComponent,
+    DangerButtonComponent,
+    IconButtonComponent,
+    MadButtonDirective,
+    MadButtonGroupComponent,
+  ],
 })
-export class ButtonModule {}
+export class ButtonModule {
+}

--- a/projects/material-addons/src/lib/button/button.ts
+++ b/projects/material-addons/src/lib/button/button.ts
@@ -4,3 +4,5 @@ export {LinkButtonComponent} from './flat-button/link-button.component';
 export {IconButtonComponent} from './icon-button/icon-button.component';
 export {OutlineButtonComponent} from './outline-button/outline-button.component';
 export {PrimaryButtonComponent} from './primary-button/primary-button.component';
+export {MadButtonDirective} from './mad-button/mad-button.directive';
+export {MadButtonGroupComponent} from './mad-button-group/mad-button-group.component';

--- a/projects/material-addons/src/lib/button/mad-button-group/mad-button-group.component.ts
+++ b/projects/material-addons/src/lib/button/mad-button-group/mad-button-group.component.ts
@@ -1,0 +1,10 @@
+import {Component, HostBinding} from '@angular/core';
+
+@Component({
+  selector: 'mad-button-group',
+  template: '<ng-content></ng-content>',
+  styleUrls: []
+})
+export class MadButtonGroupComponent {
+  @HostBinding('class.mad-button-group') setClass = true
+}

--- a/projects/material-addons/src/lib/button/mad-button/mad-button.directive.ts
+++ b/projects/material-addons/src/lib/button/mad-button/mad-button.directive.ts
@@ -1,0 +1,63 @@
+import {Directive, ElementRef, Input, OnChanges, OnInit, Optional, Renderer2, SimpleChanges} from '@angular/core';
+import {ThemePalette} from '@angular/material/core';
+import {MatAnchor, MatButton} from '@angular/material/button';
+
+@Directive({
+  selector: '[madButton]'
+})
+export class MadButtonDirective implements OnInit, OnChanges {
+  static readonly UPPERCASE_CLASS = "mad-uppercase"
+  static readonly OUTLINE_CLASS = "mad-outline"
+  static readonly DEFAULT_COLOR = "primary"
+
+  private matComponent: MatAnchor | MatButton
+
+  @Input() outline = true
+  @Input() uppercase = true
+  @Input() color: ThemePalette;
+
+  constructor(
+    private renderer: Renderer2,
+    private elementRef: ElementRef<HTMLButtonElement | HTMLAnchorElement>,
+    @Optional() anchor: MatAnchor,
+    @Optional() button: MatButton
+  ) {
+    this.matComponent = anchor || button
+    if(!this.matComponent){
+      console.error('MadButtonGroupComponent needs to be applied on a MatButton')
+    }
+  }
+
+  ngOnInit() {
+    this.setUppercase()
+    this.setOutline()
+
+    this.matComponent.color = this.color || MadButtonDirective.DEFAULT_COLOR
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['outline']) {
+      this.setUppercase()
+    }
+    if (changes['uppercase']) {
+      this.setOutline()
+    }
+  }
+
+  setUppercase() {
+    this.addOrRemoveClass(this.uppercase, MadButtonDirective.UPPERCASE_CLASS)
+  }
+
+  setOutline() {
+    this.addOrRemoveClass(this.outline, MadButtonDirective.OUTLINE_CLASS)
+  }
+
+  addOrRemoveClass(condition: boolean, className: string) {
+    if (condition) {
+      this.renderer.addClass(this.elementRef.nativeElement, className)
+    } else {
+      this.renderer.removeClass(this.elementRef.nativeElement, className)
+    }
+  }
+
+}

--- a/projects/material-addons/src/themes/common/button.scss
+++ b/projects/material-addons/src/themes/common/button.scss
@@ -1,0 +1,25 @@
+.mdc-button.mad-uppercase {
+  text-transform: uppercase;
+}
+
+.mad-outline.mat-mdc-outlined-button:not(:disabled) {
+  --mdc-outlined-button-outline-color: var(--mdc-outlined-button-label-text-color)
+}
+
+mad-button-group.mad-button-group {
+  button {
+    border-left-width: 0;
+    border-radius: 0;
+
+    &:first-child {
+      border-left-width: 1px;
+      border-bottom-left-radius: var(--mdc-outlined-button-container-shape, var(--mdc-shape-small, 4px));
+      border-top-left-radius: var(--mdc-outlined-button-container-shape, var(--mdc-shape-small, 4px));
+    }
+
+    &:last-child {
+      border-bottom-right-radius: var(--mdc-outlined-button-container-shape, var(--mdc-shape-small, 4px));
+      border-top-right-radius: var(--mdc-outlined-button-container-shape, var(--mdc-shape-small, 4px));
+    }
+  }
+}

--- a/projects/material-addons/src/themes/pbv.scss
+++ b/projects/material-addons/src/themes/pbv.scss
@@ -1,6 +1,7 @@
 @use './common/styles' as common;
 @use './common/theme' as theme;
 @use '@angular/material' as mat;
+@import 'common/button';
 
 $theme-name: 'pbv';
 

--- a/projects/material-addons/src/themes/poa.scss
+++ b/projects/material-addons/src/themes/poa.scss
@@ -2,6 +2,7 @@
 @use './common/styles' as common;
 @use './common/theme' as theme;
 @use '@angular/material' as mat;
+@import 'common/button';
 
 $theme-name: 'poa';
 

--- a/projects/material-addons/src/themes/poba.scss
+++ b/projects/material-addons/src/themes/poba.scss
@@ -1,6 +1,7 @@
 @use './common/styles' as common;
 @use './common/theme' as theme;
 @use '@angular/material' as mat;
+@import 'common/button';
 
 $theme-name: 'poba';
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -78,7 +78,6 @@ import {DataTableBasicComponent} from './example-components/data-table-basic/dat
 import {CardExpandableComponent} from './example-components/card-expandable/card-expandable.component';
 import {ReadOnlyFieldErrorComponent} from './example-components/read-only-field-error/read-only-field-error.component';
 import {QuickListExtendedComponent} from './example-components/quick-list-extended/quick-list-extended.component';
-import {MadButtonsComponent} from './example-components/mad-buttons/mad-buttons.component';
 import {MadButtonsDemoComponent} from './component-demos/mad-buttons-demo/mad-buttons-demo.component';
 import {ThrottleClickComponent} from './example-components/throttle-click/throttle-click.component';
 import {ThrottleClickDemoComponent} from './component-demos/throttle-click-demo/throttle-click-demo.component';
@@ -112,6 +111,8 @@ import {
 } from './example-components/data-table-parent-height/data-table-parent-height.component';
 import {DataTableDevModule} from './dev-components/data-table/data-table-dev.module';
 import {FullPageLayoutsRoutingModule} from "./full-page-layouts/full-page-layouts-routing.module";
+import {MadButtonsComponent} from './example-components/mad-buttons/mad-buttons.component';
+import {MadButtonGroupComponent} from './example-components/mad-button-group/mad-button-group.component';
 
 export function HttpLoaderFactory(http: HttpClient): TranslateHttpLoader {
   return new TranslateHttpLoader(http, './assets/i18n/');
@@ -144,6 +145,7 @@ export function HttpLoaderFactory(http: HttpClient): TranslateHttpLoader {
     CardEditableComponent,
     CardReadonlyComponent,
     MadButtonsComponent,
+    MadButtonGroupComponent,
     QuickListDemoComponent,
     QuickListBasicComponent,
     QuickListExtendedComponent,

--- a/src/app/component-demos/mad-buttons-demo/mad-buttons-demo.component.html
+++ b/src/app/component-demos/mad-buttons-demo/mad-buttons-demo.component.html
@@ -27,3 +27,8 @@ Import the
 <p>A good reference for button usage can be found in the <a href="https://clarity.design/documentation/buttons" target="_blank">Clarity button styleguide</a>.</p>
 
 <example-viewer [example]="madButtonsComponent"></example-viewer>
+
+<h2>Groups</h2>
+use <strong>MadButtonGroup</strong>  to wrap <strong>MadButton</strong> into a group.
+<example-viewer [example]="madButtonGroupComponent"></example-viewer>
+

--- a/src/app/component-demos/mad-buttons-demo/mad-buttons-demo.component.ts
+++ b/src/app/component-demos/mad-buttons-demo/mad-buttons-demo.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { Example } from '../../components/example-viewer/example.class';
 import {MadButtonsComponent} from "../../example-components/mad-buttons/mad-buttons.component";
+import {MadButtonGroupComponent} from '../../example-components/mad-button-group/mad-button-group.component';
 
 @Component({
   selector: 'app-mad-buttons-demo',
@@ -9,4 +10,5 @@ import {MadButtonsComponent} from "../../example-components/mad-buttons/mad-butt
 })
 export class MadButtonsDemoComponent {
   madButtonsComponent = new Example(MadButtonsComponent, 'mad-buttons', 'Material Addons Buttons');
+  madButtonGroupComponent = new Example(MadButtonGroupComponent, 'mad-button-group', 'Material Addons Button Groups');
 }

--- a/src/app/example-components/mad-button-group/mad-button-group.component.html
+++ b/src/app/example-components/mad-button-group/mad-button-group.component.html
@@ -1,0 +1,14 @@
+<div style="display: flex; gap: 1em">
+
+  <mad-button-group>
+    <button mat-flat-button madButton>madButton 1</button>
+    <button mat-stroked-button madButton>madButton 2</button>
+    <button mat-stroked-button madButton>madButton 3</button>
+  </mad-button-group>
+
+  <mad-button-group>
+    <button mat-stroked-button madButton>madButton A</button>
+    <button mat-stroked-button madButton [uppercase]="true">madButton b</button>
+  </mad-button-group>
+
+</div>

--- a/src/app/example-components/mad-button-group/mad-button-group.component.ts
+++ b/src/app/example-components/mad-button-group/mad-button-group.component.ts
@@ -1,0 +1,10 @@
+import {Component} from '@angular/core';
+
+
+@Component({
+  selector: 'mad-button-group-showcase',
+  templateUrl: './mad-button-group.component.html',
+  styleUrls: ['./mad-button-group.component.scss'],
+})
+export class MadButtonGroupComponent {
+}

--- a/src/app/example-components/mad-buttons/mad-buttons.component.html
+++ b/src/app/example-components/mad-buttons/mad-buttons.component.html
@@ -1,8 +1,15 @@
-<mad-primary-button [title]="'Save'">Save</mad-primary-button>
-<mad-outline-button [title]="'Cancel'">Cancel</mad-outline-button>
-<mad-danger-button>Delete forever</mad-danger-button>
-<mad-link-button [title]="'Add Item'">Add Item</mad-link-button>
-<mad-icon-button [title]="'Create'">
-  <mat-icon>create</mat-icon>
-</mad-icon-button>
-
+<div style="display: flex; flex-direction: column; gap: 1em">
+  <div style="display: flex; gap: 1em">
+    <mad-primary-button [title]="'Save'">Save</mad-primary-button>
+    <mad-outline-button [title]="'Cancel'">Cancel</mad-outline-button>
+    <mad-danger-button>Delete forever</mad-danger-button>
+    <mad-link-button [title]="'Add Item'">Add Item</mad-link-button>
+    <mad-icon-button [title]="'Create'">
+      <mat-icon>create</mat-icon>
+    </mad-icon-button>
+  </div>
+  <div style="display: flex; gap: 1em">
+    <button mat-stroked-button madButton>madButton</button>
+    <button mat-stroked-button madButton [outline]="false" [uppercase]="false" color="warn">madButton 2</button>
+  </div>
+</div>


### PR DESCRIPTION
### Description

Add MaterialAddons Button and ButtonGroups

MadButton: 
![image](https://user-images.githubusercontent.com/116598607/225087857-f18d536a-b3a7-49de-a11a-2d2d62dd34eb.png)

MadButtonGroup:
![image](https://user-images.githubusercontent.com/116598607/225088013-82da4957-129b-4278-9db5-4ef1e1fb358c.png)

### Which Component is affected or generated?

none
