### PR TITLE
Fix border for mad-button-group, if it has disabled elements

### DIFF
--- a/projects/material-addons/package.json
+++ b/projects/material-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@porscheinformatik/material-addons",
-  "version": "15.0.11",
+  "version": "15.0.12",
   "description": "Custom theme and components for Angular Material",
   "homepage": "https://github.com/porscheinformatik/material-addons",
   "repository": {

--- a/projects/material-addons/src/themes/common/button.scss
+++ b/projects/material-addons/src/themes/common/button.scss
@@ -6,13 +6,13 @@
   --mdc-outlined-button-outline-color: var(--mdc-outlined-button-label-text-color)
 }
 
-mad-button-group.mad-button-group {
+.mad-button-group {
   button {
     border-left-width: 0;
     border-radius: 0;
 
     &:first-child {
-      border-left-width: 1px;
+      border-left-width: var(--mdc-outlined-button-outline-width, 1px);
       border-bottom-left-radius: var(--mdc-outlined-button-container-shape, var(--mdc-shape-small, 4px));
       border-top-left-radius: var(--mdc-outlined-button-container-shape, var(--mdc-shape-small, 4px));
     }
@@ -21,5 +21,14 @@ mad-button-group.mad-button-group {
       border-bottom-right-radius: var(--mdc-outlined-button-container-shape, var(--mdc-shape-small, 4px));
       border-top-right-radius: var(--mdc-outlined-button-container-shape, var(--mdc-shape-small, 4px));
     }
+
+    &:disabled:has(+ button:not(:disabled)) {
+      border-right-width: 0;
+    }
+
+    &:disabled + button:not(:disabled) {
+      border-left-width: var(--mdc-outlined-button-outline-width, 1px);
+    }
+
   }
 }

--- a/src/app/component-demos/mad-buttons-demo/mad-buttons-demo.component.html
+++ b/src/app/component-demos/mad-buttons-demo/mad-buttons-demo.component.html
@@ -29,6 +29,6 @@ Import the
 <example-viewer [example]="madButtonsComponent"></example-viewer>
 
 <h2>Groups</h2>
-use <strong>MadButtonGroup</strong>  to wrap <strong>MadButton</strong> into a group.
+Use <strong>MadButtonGroup</strong> or <em>.mad-button-group</em> to wrap <strong>MadButton</strong> into a group.
 <example-viewer [example]="madButtonGroupComponent"></example-viewer>
 

--- a/src/app/example-components/mad-button-group/mad-button-group.component.html
+++ b/src/app/example-components/mad-button-group/mad-button-group.component.html
@@ -1,14 +1,51 @@
-<div style="display: flex; gap: 1em">
+<div style="display: flex; flex-direction: column; gap: 1em">
+  <div style="display: flex; gap: 1em">
 
-  <mad-button-group>
-    <button mat-flat-button madButton>madButton 1</button>
-    <button mat-stroked-button madButton>madButton 2</button>
-    <button mat-stroked-button madButton>madButton 3</button>
-  </mad-button-group>
+    <mad-button-group>
+      <button mat-flat-button madButton>madButton 1</button>
+      <button mat-stroked-button madButton>madButton 2</button>
+      <button mat-stroked-button madButton>madButton 3</button>
+    </mad-button-group>
 
-  <mad-button-group>
-    <button mat-stroked-button madButton>madButton A</button>
-    <button mat-stroked-button madButton [uppercase]="true">madButton b</button>
-  </mad-button-group>
+    <mad-button-group>
+      <button mat-stroked-button madButton>madButton A</button>
+      <button mat-stroked-button madButton [uppercase]="true">madButton b</button>
+    </mad-button-group>
+
+  </div>
+
+  <div style="display: flex; gap: 1em">
+    <mad-button-group>
+      <button mat-stroked-button madButton [disabled]="true">A</button>
+      <button mat-stroked-button madButton>B</button>
+      <button mat-stroked-button madButton>C</button>
+      <button mat-stroked-button madButton [disabled]="true">D</button>
+      <button mat-stroked-button madButton [disabled]="true">E</button>
+      <button mat-stroked-button madButton>F</button>
+    </mad-button-group>
+    <mad-button-group>
+      <button mat-stroked-button madButton>A</button>
+      <button mat-stroked-button madButton [disabled]="true">B</button>
+    </mad-button-group>
+  </div>
+
+  <div style="display: flex; gap: 1em">
+    <mad-button-group>
+      <button mat-flat-button madButton [disabled]="true">A</button>
+      <button mat-flat-button madButton>B</button>
+      <button mat-flat-button madButton>C</button>
+      <button mat-flat-button madButton [disabled]="true">D</button>
+      <button mat-flat-button madButton [disabled]="true">E</button>
+      <button mat-flat-button madButton>F</button>
+    </mad-button-group>
+
+    <div class="mad-button-group">
+      <button mat-flat-button madButton>A</button>
+      <button mat-flat-button madButton [disabled]="true">B</button>
+      <button mat-flat-button madButton>C</button>
+      <button mat-flat-button madButton [disabled]="true">D</button>
+    </div>
+  </div>
+
 
 </div>


### PR DESCRIPTION
### Description

Fix border for mad-button-group, if it has disabled elements

### Which Component is affected or generated?

mad-button-group

### img

![image](https://github.com/lukaspoeberl/material-addons/assets/116598607/f1ffa809-4897-4f41-8c38-57afbcf1fab7)
