### PR TITLE
Remove mdc-list-item__primary-text overriding class on styles.scss

### DIFF
--- a/projects/material-addons/src/themes/common/styles.scss
+++ b/projects/material-addons/src/themes/common/styles.scss
@@ -332,11 +332,6 @@ mat-icon.mat-icon.narrow-icon {
   margin-left: 0;
 }
 
-.mdc-list-item__primary-text {
-  font-size: 14px;
-  color: #737373 !important;
-}
-
 button.mat-mdc-menu-item {
   min-height: 38px;
 }


### PR DESCRIPTION
### Description

Removed overriding class for .mdc-list-item__primary-tex

### Which Component is affected or generated?

NONE
